### PR TITLE
DS-254 Fix Activities Filter when chosen first

### DIFF
--- a/openy_af4_vue_app/src/components/steps/SelectActivities.vue
+++ b/openy_af4_vue_app/src/components/steps/SelectActivities.vue
@@ -111,6 +111,12 @@ export default {
         if (this.firstStep && !this.optionsCount(key)) {
           return
         }
+        
+        // Filter out excluded or limited categories.
+        if (!this.excludeByCategory.length || !this.limitByCategory.length) {
+          filteredActivities[key] = activityGroup
+          return
+        }
 
         const filteredValue = activityGroup.value.filter(item => {
           let r = false


### PR DESCRIPTION
Cherry-pick https://github.com/ymcatwincities/openy_activity_finder/pull/201 to resolve https://yusa.atlassian.net/browse/DS-254?focusedCommentId=11043

To test:

- go to the AF4 start page
- select "Activity" as your first filter
- observe activities appear