### PR TITLE
DS-427 Add Activity Finder block for the Layout Builder

### DIFF
--- a/modules/lb_activity_finder/config/install/block_content.type.lb_activity_finder.yml
+++ b/modules/lb_activity_finder/config/install/block_content.type.lb_activity_finder.yml
@@ -2,6 +2,6 @@ langcode: en
 status: true
 dependencies: {  }
 id: lb_activity_finder
-label: 'Activity Finder'
+label: 'Activity Finder v4'
 revision: 0
-description: 'A component to add Activity Finder block to Layout Builder.'
+description: 'A component to add Activity Finder v4 block to Layout Builder.'

--- a/modules/lb_activity_finder/config/install/block_content.type.lb_activity_finder.yml
+++ b/modules/lb_activity_finder/config/install/block_content.type.lb_activity_finder.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: lb_activity_finder
+label: 'Activity Finder'
+revision: 0
+description: 'A component to add Activity Finder block to Layout Builder.'

--- a/modules/lb_activity_finder/config/install/core.entity_form_display.block_content.lb_activity_finder.default.yml
+++ b/modules/lb_activity_finder/config/install/core.entity_form_display.block_content.lb_activity_finder.default.yml
@@ -1,0 +1,35 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.lb_activity_finder
+    - field.field.block_content.lb_activity_finder.field_block
+  module:
+    - plugin
+id: block_content.lb_activity_finder.default
+targetEntityType: block_content
+bundle: lb_activity_finder
+mode: default
+content:
+  field_block:
+    type: 'plugin_selector:plugin_select_list'
+    weight: 27
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  info:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/lb_activity_finder/config/install/core.entity_view_display.block_content.lb_activity_finder.default.yml
+++ b/modules/lb_activity_finder/config/install/core.entity_view_display.block_content.lb_activity_finder.default.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.lb_activity_finder
+    - field.field.block_content.lb_activity_finder.field_block
+  module:
+    - plugin
+id: block_content.lb_activity_finder.default
+targetEntityType: block_content
+bundle: lb_activity_finder
+mode: default
+content:
+  field_block:
+    type: plugin_block_built
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/modules/lb_activity_finder/config/install/field.field.block_content.lb_activity_finder.field_block.yml
+++ b/modules/lb_activity_finder/config/install/field.field.block_content.lb_activity_finder.field_block.yml
@@ -19,7 +19,7 @@ default_value:
     plugin_id: activity_finder_4
     plugin_configuration:
       id: activity_finder_4
-      label: 'Activity Finder'
+      label: 'Activity Finder v4'
       label_display: '0'
       provider: openy_activity_finder
       limit_by_category_daxko: null

--- a/modules/lb_activity_finder/config/install/field.field.block_content.lb_activity_finder.field_block.yml
+++ b/modules/lb_activity_finder/config/install/field.field.block_content.lb_activity_finder.field_block.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.lb_activity_finder
+    - field.storage.block_content.field_block
+  module:
+    - plugin
+id: block_content.lb_activity_finder.field_block
+field_name: field_block
+entity_type: block_content
+bundle: lb_activity_finder
+label: Block
+description: 'A reference to the Activity Finder 4 block.'
+required: true
+translatable: false
+default_value:
+  -
+    plugin_id: activity_finder_4
+    plugin_configuration:
+      id: activity_finder_4
+      label: 'Activity Finder'
+      label_display: '0'
+      provider: openy_activity_finder
+      limit_by_category_daxko: null
+      limit_by_category: {  }
+      exclude_by_category: {  }
+      exclude_by_location: {  }
+      legacy_mode: 0
+      weeks_filter: 0
+      hide_home_branch_block: 0
+      background_image: ''
+    plugin_configuration_schema_id: block.settings.activity_finder_4
+default_value_callback: ''
+settings: {  }
+field_type: 'plugin:block'

--- a/modules/lb_activity_finder/config/install/field.storage.block_content.field_block.yml
+++ b/modules/lb_activity_finder/config/install/field.storage.block_content.field_block.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - plugin
+id: block_content.field_block
+field_name: field_block
+entity_type: block_content
+type: 'plugin:block'
+settings: {  }
+module: plugin
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/lb_activity_finder/config/install/language.content_settings.block_content.lb_activity_finder.yml
+++ b/modules/lb_activity_finder/config/install/language.content_settings.block_content.lb_activity_finder.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.lb_activity_finder
+id: block_content.lb_activity_finder
+target_entity_type_id: block_content
+target_bundle: lb_activity_finder
+default_langcode: site_default
+language_alterable: false

--- a/modules/lb_activity_finder/lb_activity_finder.features.yml
+++ b/modules/lb_activity_finder/lb_activity_finder.features.yml
@@ -1,0 +1,5 @@
+excluded:
+  - field.field.node.article_lb.layout_builder__layout
+  - field.field.node.landing_page_lb.layout_builder__layout
+  - field.storage.node.layout_builder__layout
+required: true

--- a/modules/lb_activity_finder/lb_activity_finder.info.yml
+++ b/modules/lb_activity_finder/lb_activity_finder.info.yml
@@ -1,11 +1,11 @@
 name: 'LB Activity Finder'
 type: module
 description: Helper module to show "Activity Finder" block in Layout Builder.
-core_version_requirement: ^8 || ^9 || ^10
+core_version_requirement: ^8.8 || ^9 || ^10
 dependencies:
   - block_content
   - layout_builder
   - plugin
   - y_lb
   - yusaopeny_activity_finder
-version: 9.x-1.0
+version: 1.0.0

--- a/modules/lb_activity_finder/lb_activity_finder.info.yml
+++ b/modules/lb_activity_finder/lb_activity_finder.info.yml
@@ -1,0 +1,11 @@
+name: 'LB Activity Finder'
+type: module
+description: Helper module to show "Activity Finder" block in Layout Builder.
+core_version_requirement: ^8 || ^9 || ^10
+dependencies:
+  - block_content
+  - layout_builder
+  - plugin
+  - y_lb
+  - yusaopeny_activity_finder
+version: 9.x-1.0

--- a/modules/lb_activity_finder/lb_activity_finder.module
+++ b/modules/lb_activity_finder/lb_activity_finder.module
@@ -24,7 +24,7 @@ function lb_activity_finder_theme() {
  */
 function lb_activity_finder_preprocess_block__lb_activity_finder(&$variables) {
   if ($variables['in_preview']) {
-    $variables['in_preview_placeholder'] = t('Activity Finder: To see your changes in this block, please save the layout.');
+    $variables['in_preview_placeholder'] = t('Activity Finder v4: To see your changes in this block, please save the layout.');
   }
 }
 
@@ -94,7 +94,7 @@ function _select_block_field_after_build($element, FormStateInterface $form_stat
     // Hide the select block field.
     $element[0]['plugin_selector']['container']['select']['container']['#attributes']['class'][] = 'hidden';
     // Override a text before edit the AF block settings.
-    $element[0]['plugin_selector']['container']['plugin_form']['admin_label']['#title'] = t('Please configure your Activity Finder block.');
+    $element[0]['plugin_selector']['container']['plugin_form']['admin_label']['#title'] = t('Please configure your Activity Finder v4 block.');
     unset($element[0]['plugin_selector']['container']['plugin_form']['admin_label']['#plain_text']);
   }
   return $element;

--- a/modules/lb_activity_finder/lb_activity_finder.module
+++ b/modules/lb_activity_finder/lb_activity_finder.module
@@ -1,0 +1,101 @@
+<?php
+
+/**
+* @file
+* Contains lb_activity_finder module hooks.
+*/
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_theme().
+ */
+function lb_activity_finder_theme() {
+  return [
+    'block__lb_activity_finder' => [
+      'base hook' => 'block',
+      'template' => 'block--lb-activity-finder',
+    ]
+  ];
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function lb_activity_finder_preprocess_block__lb_activity_finder(&$variables) {
+  if ($variables['in_preview']) {
+    $variables['in_preview_placeholder'] = t('Activity Finder: To see your changes in this block, please save the layout.');
+  }
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function lb_activity_finder_form_alter(&$form, FormStateInterface $form_state) {
+  // Block configuration form.
+  if (in_array($form['#form_id'],
+    [
+      'layout_builder_add_block',
+      'layout_builder_update_block',
+    ]
+  )) {
+    /** @var \Drupal\layout_builder\Form\ConfigureBlockFormBase $form_object */
+    $form_object = $form_state->getFormObject();
+    $component = $form_object->getCurrentComponent();
+    $plugin = $component->getPlugin();
+    $block_id = $plugin->getDerivativeId() ?? $plugin->getBaseId();
+    // Hide title fields that related to inline block itself.
+    $form['settings']['admin_label']['#access'] = FALSE;
+    $form['settings']['label']['#access'] = FALSE;
+    $form['settings']['label_display']['#access'] = FALSE;
+
+    if (in_array($block_id,
+      [
+        'lb_activity_finder',
+      ])) {
+      if (isset($form['settings']['block_form'])) {
+        $form['settings']['block_form']['#process'][] = '_inline_block_process';
+      }
+    }
+  }
+}
+
+/**
+ * Custom process callback for inline block elements.
+ *
+ * @param array $element
+ *   Element to process.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ *
+ * @return array
+ *   Processed element.
+ */
+function _inline_block_process(array $element, FormStateInterface $form_state) {
+  if (isset($element['field_block'])) {
+    $element['field_block']['widget']['#after_build'][] = '_select_block_field_after_build';
+  }
+  return $element;
+}
+
+/**
+ * Custom '#after_build' callback for field_block.
+ *
+ * @param array $element
+ *   Element to process.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ *
+ * @return array
+ *   Processed element.
+ */
+function _select_block_field_after_build($element, FormStateInterface $form_state) {
+  if (isset($element[0]['plugin_selector']['container'])) {
+    // Hide the select block field.
+    $element[0]['plugin_selector']['container']['select']['container']['#attributes']['class'][] = 'hidden';
+    // Override a text before edit the AF block settings.
+    $element[0]['plugin_selector']['container']['plugin_form']['admin_label']['#title'] = t('Please configure your Activity Finder block.');
+    unset($element[0]['plugin_selector']['container']['plugin_form']['admin_label']['#plain_text']);
+  }
+  return $element;
+}

--- a/modules/lb_activity_finder/templates/block--lb-activity-finder.html.twig
+++ b/modules/lb_activity_finder/templates/block--lb-activity-finder.html.twig
@@ -1,0 +1,48 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - block_content: Block content entity instance with all available fields.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+{% set classes = [
+  'block',
+  'block-' ~ configuration.provider|clean_class,
+  'block-' ~ plugin_id|clean_class
+] %}
+
+<div{{ attributes.addClass(classes).setAttribute('id', plugin_id|clean_class ~ configuration['block_revision_id']) }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {% if in_preview %}
+      {{ in_preview_placeholder }}
+    {% else %}
+      {{ content }}
+    {% endif %}
+  {% endblock %}
+</div>

--- a/src/Plugin/Block/ActivityFinder4Block.php
+++ b/src/Plugin/Block/ActivityFinder4Block.php
@@ -295,7 +295,7 @@ class ActivityFinder4Block extends BlockBase implements ContainerFactoryPluginIn
       'images_library',
       $conf['background_image'],
       1,
-      'preview'
+      'thumbnail_for_preview'
     );
     // Convert the wrapping container to a details element.
     $form['background_image']['#type'] = 'details';


### PR DESCRIPTION
Issue: [DS-427](https://yusa.atlassian.net/browse/DS-427)

The PR provides the ability to add the Activity Finder block to the LB.
How it looks like:
![DS-427-ConfigureBlock-1](https://user-images.githubusercontent.com/744406/227475686-662a4132-b8f7-432e-b840-1318cb15e155.png)
![DS-427-ConfigureBlock-2](https://user-images.githubusercontent.com/744406/227475812-04b678a7-0b93-4287-be05-873526724d23.png)

In LB the AF app doesn't initial properly after block changes (needs to reload the page), so we use a placeholder instead empty space
![DS-427-LBplaceholder](https://user-images.githubusercontent.com/744406/227476529-935b05be-1e6a-4473-8ab3-3c5aba8b978a.png)

On front:
![DS-427-AF4-Front](https://user-images.githubusercontent.com/744406/227476583-f8eabc3c-5cfc-45c5-b153-8c15556671a7.png)
