### PR TITLE
Fix missing icons for collapsible fieldset.

### DIFF
--- a/openy_af4_vue_app/src/components/Fieldset.vue
+++ b/openy_af4_vue_app/src/components/Fieldset.vue
@@ -16,8 +16,8 @@
           {{ counterOptions | formatPlural('1 Result', '@count Results') }}
         </span>
         <span v-if="collapsible && !counter" class="icon">
-          <font-awesome-icon icon="plus" />
-          <font-awesome-icon icon="minus" />
+          <font-awesome-icon icon="plus-circle" />
+          <font-awesome-icon icon="minus-circle" />
         </span>
         <span v-else-if="collapsible && counter && hideCounter" class="icon">
           <font-awesome-icon icon="minus" />
@@ -166,8 +166,8 @@ export default {
       padding: 0 8px;
     }
 
-    &.collapsed .fa-minus,
-    &:not(.collapsed) .fa-plus {
+    &.collapsed .fa-minus-circle,
+    &:not(.collapsed) .fa-plus-circle {
       display: none;
     }
 

--- a/openy_af4_vue_app/src/main.js
+++ b/openy_af4_vue_app/src/main.js
@@ -10,11 +10,13 @@ import {
   faClock,
   faChevronDown,
   faChevronUp,
-  faBookmark
+  faBookmark,
+  faPlusCircle,
+  faMinusCircle
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
-library.add([faFilter, faCalendar, faMoneyBill, faClock, faChevronDown, faChevronUp, faBookmark])
+library.add([faFilter, faCalendar, faMoneyBill, faClock, faChevronDown, faChevronUp, faBookmark, faPlusCircle, faMinusCircle])
 Vue.component('font-awesome-icon', FontAwesomeIcon)
 
 // Listen to custom event to track events in Google Analytics.


### PR DESCRIPTION
The plus/minus fontawesome icons are missing after the update to 4.1.5:

![image](https://github.com/YCloudYUSA/yusaopeny_activity_finder/assets/15172796/11aa1056-0f48-4492-94fd-0fd995c4ff10)

This is because the icons are not imported in the `main.js`.
Additionally, the new "plus" icon is not embedded in circle, so we need to replace `icon="plus"`, with `icon="plus-circle"`. 