### PR TITLE
[Backport][RGTC-2563] fix: undefined array key

### DIFF
--- a/src/OpenyActivityFinderSolrBackend.php
+++ b/src/OpenyActivityFinderSolrBackend.php
@@ -901,7 +901,7 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
           $ages_y[$i] = $ages[$i] . \Drupal::translation()->formatPlural($ages[$i], ' month', ' months' . $plus);
         }
         else {
-          if ($ages[$i] == 0 && isset($ages[$i + 1])) {
+          if (isset($ages[$i + 1]) && $ages[$i] == 0) {
             $ages_y[$i] = $ages[$i];
           }
         }


### PR DESCRIPTION
Backport from YN https://github.com/ymcatwincities/yn/pull/6467
Issue:
```Warning: Undefined array key 2 in Drupal\openy_activity_finder\OpenyActivityFinderSolrBackend->convertData() (line 869 of /srv/www/ygtc_github/releases/20230130100036/docroot/modules/contrib/openy_activity_finder/src/OpenyActivityFinderSolrBackend.php) #0 /srv/www/ygtc_github/releases/20230130100036/docroot/core/includes/bootstrap.inc(347): _drupal_error_handler_real(2, 'Undefined array...', '/srv/www/ygtc_g...', 869)```
