### PR TITLE
fix: Remove call to deprecated drupal_get_path

### DIFF
--- a/openy_activity_finder.install
+++ b/openy_activity_finder.install
@@ -265,7 +265,7 @@ function _af_config_import($import = ['optional' => ['search_api.index.default']
  */
 function openy_activity_finder_update_8405() {
   $cim = \Drupal::service('config_import.importer');
-  $cim->setDirectory(drupal_get_path('module', 'openy_activity_finder') . '/config/install');
+  $cim->setDirectory(\Drupal::service('extension.list.module')->getPath('openy_activity_finder') . '/config/install');
   $config = \Drupal::config('openy_activity_finder.settings');
   if (!$config->isNew()) {
     // Import config only in case it already exists.


### PR DESCRIPTION
Fixes a deprecation from https://github.com/YCloudYUSA/yusaopeny_activity_finder/pull/20 that causes updb to fail in Drupal 10.
