### PR TITLE
Apply js-cookie patch from YDEN

### DIFF
--- a/openy_activity_finder.libraries.yml
+++ b/openy_activity_finder.libraries.yml
@@ -16,7 +16,7 @@ openy_activity_finder:
     - openy_system/vue
     - openy_system/vue-router
     - openy_system/moment
-    - core/jquery.cookie
+    - core/js-cookie
 
 openy_camp_finder:
   version: 0.1

--- a/openy_af_vue_app/components/ActivityFinder.vue
+++ b/openy_af_vue_app/components/ActivityFinder.vue
@@ -66,6 +66,21 @@
       setInitialStep: function (stepName) {
         this.initialStep = stepName;
       },
+      getCookie: function (cname) {
+        const name = cname + '='
+        const decodedCookie = decodeURIComponent(document.cookie)
+        const ca = decodedCookie.split(';')
+        for (let i = 0; i < ca.length; i++) {
+          let c = ca[i]
+          while (c[0] === ' ') {
+            c = c.slice(1)
+          }
+          if (c.startsWith(name)) {
+            return c.slice(name.length, c.length)
+          }
+        }
+        return ''
+      },
       skip: function(stepName) {
         // Lets found next step based on initial step.
         var nextStep = '';
@@ -403,15 +418,17 @@
       component.runAjaxRequest();
 
       // Initial run of ajax request if Home Branch set.
-      if (typeof jQuery.cookie('home_branch') !== 'undefined' && JSON.parse(jQuery.cookie('home_branch')).id) {
-        var homeBranchId = JSON.parse(jQuery.cookie('home_branch')).id;
-        if (typeof drupalSettings.activityFinder.locationsNidToDaxkoIdMapping !== 'undefined') {
-          if (typeof drupalSettings.activityFinder.locationsNidToDaxkoIdMapping[homeBranchId] !== 'undefined') {
-            homeBranchId = drupalSettings.activityFinder.locationsNidToDaxkoIdMapping[homeBranchId];
+      if (typeof this.getCookie('home_branch') !== 'undefined' && (this.getCookie('home_branch') !== '')) {
+        if (JSON.parse(this.getCookie('home_branch')).id) {
+          var homeBranchId = JSON.parse(this.getCookie('home_branch')).id;
+          if (typeof drupalSettings.activityFinder.locationsNidToDaxkoIdMapping !== 'undefined') {
+            if (typeof drupalSettings.activityFinder.locationsNidToDaxkoIdMapping[homeBranchId] !== 'undefined') {
+              homeBranchId = drupalSettings.activityFinder.locationsNidToDaxkoIdMapping[homeBranchId];
+            }
           }
+          component.homeBranchId = homeBranchId;
+          component.runAjaxRequest({'locations': [component.homeBranchId]});
         }
-        component.homeBranchId = homeBranchId;
-        component.runAjaxRequest({'locations': [component.homeBranchId]});
       }
 
       // Listen for events from components.


### PR DESCRIPTION
As per https://www.drupal.org/node/3104677, `core/jquery.cookie` is deprecated and should be replaced with `core/js-cookie`.