### PR TITLE
feat: Allow additional content types to be used by Activity Finder

### DIFF
--- a/config/install/openy_activity_finder.settings.yml
+++ b/config/install/openy_activity_finder.settings.yml
@@ -2,6 +2,10 @@ backend: openy_activity_finder.solr_backend
 index: default
 bs_version: 3
 ages: "6,6mos\r\n12,12mos\r\n18,18mos\r\n24,2yrs\r\n36,3yrs\r\n48,4yrs\r\n60,5yrs\r\n72,6yrs\r\n84,7yrs\r\n96,8yrs\r\n108,9yrs\r\n120,10yrs\r\n132,11yrs\r\n144,12yrs\r\n156,13yrs\r\n168,14yrs\r\n180,15yrs\r\n192,16+yrs\r\n660,55+yrs"
+location_types:
+  branch: branch
+  camp: camp
+  facility: facility
 weeks: ""
 exclude: "61"
 disable_search_box: 0

--- a/openy_activity_finder.info.yml
+++ b/openy_activity_finder.info.yml
@@ -6,3 +6,4 @@ version: 4.1.5
 core_version_requirement: ^8 || ^9 || ^10
 dependencies:
   - drupal:rest
+  - openy_map

--- a/src/OpenyActivityFinderSolrBackend.php
+++ b/src/OpenyActivityFinderSolrBackend.php
@@ -31,6 +31,9 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
   // Cache ID for locations info.
   const ACTIVITY_FINDER_CACHE_TAG = 'openy_activity_finder:default';
 
+  // Default location types.
+  const DEFAULT_LOCATION_TYPES = ['branch' => 'branch', 'camp' => 'camp', 'facility' => 'facility'];
+
   /**
    * Cache default.
    *
@@ -697,7 +700,7 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
   public function getLocationsInfo() {
     $data = [];
     $cid = 'openy_activity_finder:locations_info';
-    $location_types = $this->config->get('location_types');
+    $location_types = $this->config->get('location_types') ?? self::DEFAULT_LOCATION_TYPES;
 
     if ($cache = $this->cache->get($cid)) {
       $data = $cache->data;
@@ -810,7 +813,7 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
   public function getLocations() {
     // Array with predefined keys for sorting in application location filters.
     // $locations = ['branch' => [], 'camp' => [], 'facility' => [], ...];
-    $location_types = $this->config->get('location_types');
+    $location_types = $this->config->get('location_types') ?? self::DEFAULT_LOCATION_TYPES;
     $locations = array_map(fn($value): array => [], array_filter($location_types));
 
     $locationsInfo = $this->getLocationsInfo();

--- a/src/Plugin/Block/ActivityFinder4Block.php
+++ b/src/Plugin/Block/ActivityFinder4Block.php
@@ -238,13 +238,19 @@ class ActivityFinder4Block extends BlockBase implements ContainerFactoryPluginIn
         '#size' => 100,
         '#maxlength' => 2048,
       ];
+
+      // Use the allowed location types.
+      $location_types = array_keys(array_filter($activity_finder_settings->get('location_types')));
       $base_by_location = [
         '#type' => 'entity_autocomplete',
-        '#description' => $this->t('Separate multiple values by comma. Search for title from Branch, Camp, Facility types.'),
+        '#description' => $this->t(
+          'Separate multiple values by comma. Search for title from %types types.',
+          ['%types' => join(', ', $location_types)]
+        ),
         '#target_type' => 'node',
         '#tags' => TRUE,
         '#selection_settings' => [
-          'target_bundles' => ['branch', 'camp', 'facility'],
+          'target_bundles' => $location_types,
         ],
         '#size' => 100,
         '#maxlength' => 2048,

--- a/src/Plugin/Block/ActivityFinder4Block.php
+++ b/src/Plugin/Block/ActivityFinder4Block.php
@@ -240,7 +240,8 @@ class ActivityFinder4Block extends BlockBase implements ContainerFactoryPluginIn
       ];
 
       // Use the allowed location types.
-      $location_types = array_keys(array_filter($activity_finder_settings->get('location_types')));
+      $location_types = array_keys(array_filter($activity_finder_settings->get('location_types'))) ??
+        ['branch', 'camp', 'facility'];
       $base_by_location = [
         '#type' => 'entity_autocomplete',
         '#description' => $this->t(


### PR DESCRIPTION
These changes allow Activity Finder to use new location types that are created using the documented process of [Adding additional location types](https://ds-docs.y.org/docs/howto/map-settings-config/#adding-additional-location-types).

AF has previously hardcoded the list of `['branch', 'camp', 'facility']` a number of places and this change aims to remove that hardcoded list in exchange for a more dynamic one. Backwards compatibility is maintained as the default configuration retains that list.

Changes:

- `/admin/openy/settings/activity-finder` gets a new option, **Allowed location types** that uses the logic from Open Y Maps to list any locations that have the required `field_location_coordinates` field.
![SCR-20240220-mruj](https://github.com/YCloudYUSA/yusaopeny_activity_finder/assets/238201/6c15648b-0fac-48ed-a873-909e9f02ef45)
- AF Solr Backend filters on those location types (in addition to any locations passed in as parameters from the url)
- AF4 Block **Exclude by location** field allows filtering from nodes in any of the selected content types
![SCR-20240220-mtxu](https://github.com/YCloudYUSA/yusaopeny_activity_finder/assets/238201/e277d4b6-a0d8-48cc-ad6f-d3526ce1eed6)

This change was done in the scope of work for YMCA of Metro Denver