### PR TITLE
New installs should default to Bootstrap 4

### DIFF
--- a/config/install/openy_activity_finder.settings.yml
+++ b/config/install/openy_activity_finder.settings.yml
@@ -1,6 +1,6 @@
 backend: openy_activity_finder.solr_backend
 index: default
-bs_version: 3
+bs_version: 4
 ages: "6,6mos\r\n12,12mos\r\n18,18mos\r\n24,2yrs\r\n36,3yrs\r\n48,4yrs\r\n60,5yrs\r\n72,6yrs\r\n84,7yrs\r\n96,8yrs\r\n108,9yrs\r\n120,10yrs\r\n132,11yrs\r\n144,12yrs\r\n156,13yrs\r\n168,14yrs\r\n180,15yrs\r\n192,16+yrs\r\n660,55+yrs"
 location_types:
   branch: branch


### PR DESCRIPTION
Default to Bootstrap 4.

I don't think we need an upgrade path here as most who are using this would have set it already, but this will clean up some unwanted behavior on the sandboxes and new installs.