### PR TITLE
[DS-1491] Prevent undefined array key warning in ActivityFinder4Block

### DIFF
--- a/src/Plugin/Block/ActivityFinder4Block.php
+++ b/src/Plugin/Block/ActivityFinder4Block.php
@@ -123,7 +123,12 @@ class ActivityFinder4Block extends BlockBase implements ContainerFactoryPluginIn
 
     // Remove empty programs and subprograms.
     $results = $backend->runProgramSearch([], 0);
-    $facets = $results['facets']['field_activity_category'];
+
+    $facets = [];
+    if (!empty($results['facets']['field_activity_category'])) {
+      $facets = $results['facets']['field_activity_category'];
+    }
+
     $activeSubPrograms = [];
     foreach ($facets as $item) {
       if (isset($item['id']) && !empty($item['id'])) {


### PR DESCRIPTION
Jira: https://yusa.atlassian.net/browse/DS-1491

Added a check to ensure `field_activity_category` key exists in the search results before attempting to access it. This prevents the "Undefined array key" warning and ensures the code runs correctly even if the key is not present.

**Steps to Reproduce**
- [ ] Add an Activity Finder block
- [ ] Empty the solr index
- [ ] Observe PHP warnings