### PR TITLE
Update ActivityFinder4Block.php

### DIFF
--- a/src/Plugin/Block/ActivityFinder4Block.php
+++ b/src/Plugin/Block/ActivityFinder4Block.php
@@ -347,7 +347,7 @@ class ActivityFinder4Block extends BlockBase implements ContainerFactoryPluginIn
     $form['weeks_filter'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Weeks filter'),
-      '#description' => $this->t('Replace date/time filter with weeks filter.'),
+      '#description' => $this->t('Replace date/time filter with weeks filter. Note: This filter will only return sessions that include "Camp" in the title or room fields.'),
       '#default_value' => $conf['weeks_filter'],
     ];
 


### PR DESCRIPTION
The weeks filter only works with sessions that include 'Camp' in the title or room fields.
I'm adding this note as a help text in the block config form.

Reference: https://github.com/YCloudYUSA/yusaopeny_activity_finder/blob/5.x/src/Plugin/search_api/processor/Week.php#L113