### PR TITLE
Catch SearchApiSolrException when server is unavailable

### DIFF
--- a/src/OpenyActivityFinderSolrBackend.php
+++ b/src/OpenyActivityFinderSolrBackend.php
@@ -117,7 +117,13 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
    */
   public function runProgramSearch($parameters, $log_id) {
     // Make a request to Search API.
-    $results = $this->doSearchRequest($parameters);
+    try {
+      $results = $this->doSearchRequest($parameters);
+    }
+    catch (\Exception $e) {
+      $this->loggerChannel->error($e->getMessage());
+      return [];
+    }
 
     // Get results count.
     $data['count'] = $results->getResultCount();


### PR DESCRIPTION
If the solr server is unavailable Activity Finder will throw a 500 error and WSOD. This catches the error and logs it without breaking the rest of the page.

> Drupal\search_api_solr\SearchApiSolrException: An error occurred while searching, try again later. in Drupal\search_api_solr\Plugin\search_api\backend\SearchApiSolrBackend->search() (line 1982 of modules/contrib/search_api_solr/src/Plugin/search_api/backend/SearchApiSolrBackend.php).

Fix via YMCA of Central Ohio
