### PR TITLE
Report error if Solr index can not be found

### DIFF
--- a/src/OpenyActivityFinderSolrBackend.php
+++ b/src/OpenyActivityFinderSolrBackend.php
@@ -171,7 +171,7 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
     $index = Index::load($index_id);
     if (!$index) {
       $this->loggerChannel->error('Index not found.');
-      throw new \Exception('Index not found.');
+      return FALSE;
     }
     $query = $index->query();
     $keys = !empty($parameters['keywords']) ? $parameters['keywords'] : '';

--- a/src/OpenyActivityFinderSolrBackend.php
+++ b/src/OpenyActivityFinderSolrBackend.php
@@ -164,10 +164,15 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
 
   /**
    * {@inheritdoc}
+   * @throws \Exception
    */
   public function doSearchRequest($parameters) {
     $index_id = $this->config->get('index') ? $this->config->get('index') : 'default';
     $index = Index::load($index_id);
+    if (!$index) {
+      $this->loggerChannel->error('Index not found.');
+      throw new \Exception('Index not found.');
+    }
     $query = $index->query();
     $keys = !empty($parameters['keywords']) ? $parameters['keywords'] : '';
     if ($keys) {


### PR DESCRIPTION
When the AF block is added to a page and Solr is not accessible, it can throw another error related to https://github.com/YCloudYUSA/yusaopeny_activity_finder/pull/52.

This logs the missing index to Drupal logs and throws an error so that the block doesn't break the entire page.