### PR TITLE
fix: view unpublished subprograms in filters

### DIFF
--- a/src/OpenyActivityFinderSolrBackend.php
+++ b/src/OpenyActivityFinderSolrBackend.php
@@ -730,7 +730,6 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
         ->getStorage('node')
         ->getQuery()
         ->condition('type', 'program_subcategory')
-        ->condition('status', '1')
         ->accessCheck(FALSE)
         ->execute();
       $nids_chunked = array_chunk($nids, 20, TRUE);


### PR DESCRIPTION
Problem:
AF display all schedules(node session) even if they unpublished, but not display categories in filters for them