### PR TITLE
Fix condition for time comparison in WeekdaysPartsOfDay

### DIFF
--- a/src/Plugin/search_api/processor/WeekdaysPartsOfDay.php
+++ b/src/Plugin/search_api/processor/WeekdaysPartsOfDay.php
@@ -161,7 +161,7 @@ class WeekdaysPartsOfDay extends ProcessorPluginBase implements ContainerFactory
       if ($_from_time < $time12pm) {
         $time_values[] = 1;
       }
-      if ($_from_time <= $time5pm && $_to_time >= $time12pm) {
+      if ($_from_time < $time5pm && $_to_time >= $time12pm) {
         $time_values[] = 2;
       }
       if ($_to_time > $time5pm) {


### PR DESCRIPTION
Activity Finder Solr backend will double-count an activity that starts at exactly 5pm as "afternoon" and "evening".

An activity starting exactly at 5pm should only be counted as evening (time_value 3), but the current condition $_from_time <= $time5pm && $_to_time >= $time12pm would also include it in afternoon (time_value 2).

Indexes should be rebuilt after this bug fix to reflect the changes. 

fix courtesy of YMCA Greater Dayton