### PR TITLE
fix: resolve PHP 8.4 implicit nullable and Symfony Request::get() deprecations

### DIFF
--- a/src/Controller/ActivityFinderController.php
+++ b/src/Controller/ActivityFinderController.php
@@ -83,23 +83,23 @@ class ActivityFinderController extends ControllerBase {
     $hash_ip_agent = substr($user_agent, 0, 50) . '   ' . $ip;
     $record = [
       'hash_ip_agent' => $hash_ip_agent,
-      'ages' => $request->get('ages'),
-      'days' => $request->get('days'),
-      'times' => $request->get('times'),
-      'daystimes' => $request->get('daystimes'),
-      'weeks' => $request->get('weeks'),
-      'locations' => $request->get('locations'),
-      'categories' => $request->get('categories'),
-      'page' => $request->get('page'),
-      'sort' => $request->get('sort'),
-      'keywords' => $request->get('keywords'),
-      'limit' => $request->get('limit'),
-      'exclude' => $request->get('exclude'),
-      'limitloc' => $request->get('limitloc'),
-      'excludeloc' => $request->get('excludeloc'),
-      'in_membership' => $request->get('in_membership'),
-      'durations' => $request->get('durations'),
-      'start_months' => $request->get('start_months'),
+      'ages' => $request->query->get('ages'),
+      'days' => $request->query->get('days'),
+      'times' => $request->query->get('times'),
+      'daystimes' => $request->query->get('daystimes'),
+      'weeks' => $request->query->get('weeks'),
+      'locations' => $request->query->get('locations'),
+      'categories' => $request->query->get('categories'),
+      'page' => $request->query->get('page'),
+      'sort' => $request->query->get('sort'),
+      'keywords' => $request->query->get('keywords'),
+      'limit' => $request->query->get('limit'),
+      'exclude' => $request->query->get('exclude'),
+      'limitloc' => $request->query->get('limitloc'),
+      'excludeloc' => $request->query->get('excludeloc'),
+      'in_membership' => $request->query->get('in_membership'),
+      'durations' => $request->query->get('durations'),
+      'start_months' => $request->query->get('start_months'),
     ];
     $record['hash'] = md5(json_encode($record));
 
@@ -155,8 +155,8 @@ class ActivityFinderController extends ControllerBase {
    * Redirect to register.
    */
   public function redirectToRegister(Request $request, $log) {
-    $details = $request->get('details');
-    $url = $request->get('url');
+    $details = $request->query->get('details');
+    $url = $request->query->get('url');
 
     if (empty($url)) {
       throw new NotFoundHttpException();

--- a/src/Plugin/search_api/processor/AgesMinMax.php
+++ b/src/Plugin/search_api/processor/AgesMinMax.php
@@ -82,7 +82,7 @@ class AgesMinMax extends ProcessorPluginBase {
   /**
    * {@inheritdoc}
    */
-  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+  public function getPropertyDefinitions(?DatasourceInterface $datasource = NULL) {
     $properties = [];
 
     if (!$datasource) {

--- a/src/Plugin/search_api/processor/DateOfDay.php
+++ b/src/Plugin/search_api/processor/DateOfDay.php
@@ -88,7 +88,7 @@ class DateOfDay extends ProcessorPluginBase implements ContainerFactoryPluginInt
   /**
    * {@inheritdoc}
    */
-  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+  public function getPropertyDefinitions(?DatasourceInterface $datasource = NULL) {
     $properties = [];
 
     if (!$datasource) {

--- a/src/Plugin/search_api/processor/Duration.php
+++ b/src/Plugin/search_api/processor/Duration.php
@@ -76,7 +76,7 @@ class Duration extends ProcessorPluginBase implements ContainerFactoryPluginInte
   /**
    * {@inheritdoc}
    */
-  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+  public function getPropertyDefinitions(?DatasourceInterface $datasource = NULL) {
     $properties = [];
 
     if (!$datasource) {

--- a/src/Plugin/search_api/processor/PartsOfDay.php
+++ b/src/Plugin/search_api/processor/PartsOfDay.php
@@ -78,7 +78,7 @@ class PartsOfDay extends ProcessorPluginBase implements ContainerFactoryPluginIn
   /**
    * {@inheritdoc}
    */
-  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+  public function getPropertyDefinitions(?DatasourceInterface $datasource = NULL) {
     $properties = [];
 
     if (!$datasource) {

--- a/src/Plugin/search_api/processor/StartMonth.php
+++ b/src/Plugin/search_api/processor/StartMonth.php
@@ -73,7 +73,7 @@ class StartMonth extends ProcessorPluginBase implements ContainerFactoryPluginIn
   /**
    * {@inheritdoc}
    */
-  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+  public function getPropertyDefinitions(?DatasourceInterface $datasource = NULL) {
     $properties = [];
 
     if (!$datasource) {

--- a/src/Plugin/search_api/processor/TimeOfDay.php
+++ b/src/Plugin/search_api/processor/TimeOfDay.php
@@ -73,7 +73,7 @@ class TimeOfDay extends ProcessorPluginBase implements ContainerFactoryPluginInt
   /**
    * {@inheritdoc}
    */
-  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+  public function getPropertyDefinitions(?DatasourceInterface $datasource = NULL) {
     $properties = [];
 
     if (!$datasource) {

--- a/src/Plugin/search_api/processor/Week.php
+++ b/src/Plugin/search_api/processor/Week.php
@@ -84,7 +84,7 @@ class Week extends ProcessorPluginBase implements ContainerFactoryPluginInterfac
   /**
    * {@inheritdoc}
    */
-  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+  public function getPropertyDefinitions(?DatasourceInterface $datasource = NULL) {
     $properties = [];
 
     if (!$datasource) {

--- a/src/Plugin/search_api/processor/WeekdaysPartsOfDay.php
+++ b/src/Plugin/search_api/processor/WeekdaysPartsOfDay.php
@@ -71,7 +71,7 @@ class WeekdaysPartsOfDay extends ProcessorPluginBase implements ContainerFactory
   /**
    * {@inheritdoc}
    */
-  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+  public function getPropertyDefinitions(?DatasourceInterface $datasource = NULL) {
     $properties = [];
 
     if (!$datasource) {


### PR DESCRIPTION
## Summary

Fixes deprecated function warnings in Activity Finder (27 patterns).

- Add `?` prefix to `DatasourceInterface $datasource = NULL` parameter in 8 search_api processors (`getPropertyDefinitions`) — parent `ProcessorInterface` already uses `?DatasourceInterface` in search_api 1.40.0
- Replace deprecated `Request::get()` with `Request::query->get()` in `ActivityFinderController`:
  - 17 calls in `getData()` (lines 86-102) — GET query string params
  - 2 calls in `redirectToRegister()` (lines 158-159) — GET query string params

## Test plan

- [ ] Clear caches (`drush cr`)
- [ ] Open Activity Finder page, run a search with filters — verify results load correctly
- [ ] Check `drush ws --type=php --count=50` — no new deprecation messages for activity_finder
- [ ] Test redirect-to-register link from search results

Refs: ITCR-1129