### PR TITLE
feat(ITCR-1131): replace EntityBrowserFormTrait with media_library in ActivityFinder4Block

### DIFF
--- a/openy_activity_finder.install
+++ b/openy_activity_finder.install
@@ -293,3 +293,77 @@ function openy_activity_finder_update_9002() {
 function openy_activity_finder_update_9004() {
   _af_config_import();
 }
+
+/**
+ * Migrate Activity Finder background_image from entity_browser to media_library format.
+ *
+ * entity_browser stored values as "media:123" (entity_type:entity_id).
+ * media_library stores just the integer ID "123".
+ * Without migration the block edit form shows empty image selection and
+ * re-saving the block would silently lose the background image.
+ */
+function openy_activity_finder_update_9005() {
+  $tables = [
+    'paragraph__field_prgf_block',
+    'paragraph_revision__field_prgf_block',
+    'block_content__field_block',
+    'block_content_revision__field_block',
+  ];
+  $database = \Drupal::database();
+  $count = 0;
+
+  foreach ($tables as $table) {
+    $count += _openy_activity_finder_migrate_background_image_table($database, $table);
+  }
+
+  return t('Migrated @count Activity Finder block(s) background_image from entity_browser to media_library format.', ['@count' => $count]);
+}
+
+/**
+ * Migrates background_image values in a single entity field table.
+ */
+function _openy_activity_finder_migrate_background_image_table($database, string $table): int {
+  if (!$database->schema()->tableExists($table)) {
+    return 0;
+  }
+
+  $field_name = preg_replace('/^(paragraph|block_content)(_revision)?__/', '', $table);
+  $id_col = $field_name . '_plugin_id';
+  $config_col = $field_name . '_plugin_configuration';
+
+  $rows = $database->select($table, 't')
+    ->fields('t', ['entity_id', 'revision_id', 'delta', $config_col])
+    ->condition($id_col, 'activity_finder_4')
+    ->execute()
+    ->fetchAll();
+
+  $count = 0;
+  foreach ($rows as $row) {
+    $count += _openy_activity_finder_migrate_background_image_row($database, $table, $config_col, $row);
+  }
+  return $count;
+}
+
+/**
+ * Migrates a single row if its background_image is in legacy format.
+ */
+function _openy_activity_finder_migrate_background_image_row($database, string $table, string $config_col, $row): int {
+  $config = unserialize($row->{$config_col});
+  $value = $config['background_image'] ?? NULL;
+
+  if (empty($value) || !is_string($value) || !str_contains($value, ':')) {
+    return 0;
+  }
+
+  [, $media_id] = explode(':', $value, 2);
+  $config['background_image'] = is_numeric($media_id) ? (int) $media_id : NULL;
+
+  $database->update($table)
+    ->fields([$config_col => serialize($config)])
+    ->condition('entity_id', $row->entity_id)
+    ->condition('revision_id', $row->revision_id)
+    ->condition('delta', $row->delta)
+    ->execute();
+
+  return 1;
+}

--- a/src/Plugin/Block/ActivityFinder4Block.php
+++ b/src/Plugin/Block/ActivityFinder4Block.php
@@ -105,12 +105,8 @@ class ActivityFinder4Block extends BlockBase implements ContainerFactoryPluginIn
 
     $image_mobile = '';
     $image_desktop = '';
-    if (!empty($conf['background_image'])) {
-      $media_id = $conf['background_image'];
-      // Backward compat: entity_browser stored "media:123", media_library stores "123".
-      if (is_string($media_id) && str_contains($media_id, ':')) {
-        [, $media_id] = explode(':', $media_id, 2);
-      }
+    $media_id = $conf['background_image'] ?? NULL;
+    if ($media_id) {
       /** @var \Drupal\media\MediaInterface|null $media */
       $media = $this->entityTypeManager->getStorage('media')->load($media_id);
       if ($media && $media->hasField('field_media_image') && !$media->get('field_media_image')->isEmpty()) {
@@ -415,7 +411,7 @@ class ActivityFinder4Block extends BlockBase implements ContainerFactoryPluginIn
       '#type' => 'media_library',
       '#allowed_bundles' => ['image'],
       '#title' => $this->t('Background image'),
-      '#default_value' => !empty($conf['background_image']) ? $conf['background_image'] : NULL,
+      '#default_value' => $conf['background_image'] ?? NULL,
       '#cardinality' => 1,
     ];
 

--- a/src/Plugin/Block/ActivityFinder4Block.php
+++ b/src/Plugin/Block/ActivityFinder4Block.php
@@ -10,7 +10,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\openy_activity_finder\OpenyActivityFinderSolrBackend;
-use Drupal\openy_system\EntityBrowserFormTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -23,8 +22,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * )
  */
 class ActivityFinder4Block extends BlockBase implements ContainerFactoryPluginInterface {
-
-  use EntityBrowserFormTrait;
 
   /**
    * Config Factory definition.
@@ -108,12 +105,20 @@ class ActivityFinder4Block extends BlockBase implements ContainerFactoryPluginIn
 
     $image_mobile = '';
     $image_desktop = '';
-    /** @var \Drupal\media\MediaInterface $media */
-    if (!empty($conf['background_image']) && $media = static::loadEntityBrowserEntity($conf['background_image'])) {
-      $image = $media->field_media_image->entity;
-      $storage = $this->entityTypeManager->getStorage('image_style');
-      $image_mobile = $storage->load('prgf_banner')->buildUrl($image->getFileUri());
-      $image_desktop = $storage->load('prgf_gallery')->buildUrl($image->getFileUri());
+    if (!empty($conf['background_image'])) {
+      $media_id = $conf['background_image'];
+      // Backward compat: entity_browser stored "media:123", media_library stores "123".
+      if (is_string($media_id) && str_contains($media_id, ':')) {
+        [, $media_id] = explode(':', $media_id, 2);
+      }
+      /** @var \Drupal\media\MediaInterface|null $media */
+      $media = $this->entityTypeManager->getStorage('media')->load($media_id);
+      if ($media && $media->hasField('field_media_image') && !$media->get('field_media_image')->isEmpty()) {
+        $image = $media->field_media_image->entity;
+        $storage = $this->entityTypeManager->getStorage('image_style');
+        $image_mobile = $storage->load('prgf_banner')->buildUrl($image->getFileUri());
+        $image_desktop = $storage->load('prgf_gallery')->buildUrl($image->getFileUri());
+      }
     }
 
     $limit_by_category = $conf['limit_by_category'];
@@ -406,17 +411,13 @@ class ActivityFinder4Block extends BlockBase implements ContainerFactoryPluginIn
       '#default_value' => $conf['skip_wizard'],
     ];
 
-    // Entity Browser element for background image.
-    $form['background_image'] = $this->getEntityBrowserForm(
-      'images_library',
-      $conf['background_image'],
-      1,
-      'thumbnail_for_preview'
-    );
-    // Convert the wrapping container to a details element.
-    $form['background_image']['#type'] = 'details';
-    $form['background_image']['#title'] = $this->t('Background image');
-    $form['background_image']['#open'] = TRUE;
+    $form['background_image'] = [
+      '#type' => 'media_library',
+      '#allowed_bundles' => ['image'],
+      '#title' => $this->t('Background image'),
+      '#default_value' => !empty($conf['background_image']) ? $conf['background_image'] : NULL,
+      '#cardinality' => 1,
+    ];
 
     return $form;
   }
@@ -447,7 +448,7 @@ class ActivityFinder4Block extends BlockBase implements ContainerFactoryPluginIn
     $this->configuration['in_memberships_filter'] = $additional_filters['in_memberships_filter'];
     $this->configuration['hide_home_branch_block'] = $form_state->getValue('hide_home_branch_block');
     $this->configuration['skip_wizard'] = $form_state->getValue('skip_wizard');
-    $this->configuration['background_image'] = $this->getEntityBrowserValue($form_state, 'background_image');
+    $this->configuration['background_image'] = $form_state->getValue('background_image');
   }
 
   /**


### PR DESCRIPTION
## Summary

- Removes hard dependency on `entity_browser` module via `EntityBrowserFormTrait` from `openy_system` — the trait causes a fatal crash at PHP autoload time when `entity_browser` is not installed (deprecated in Drupal 11.3)
- Replaces `getEntityBrowserForm()` in `blockForm()` with core `#type => media_library` element (available since Drupal 8.8, no new deps required)
- Replaces `loadEntityBrowserEntity()` in `build()` with direct `entityTypeManager->getStorage('media')->load()` call
- Adds backward compatibility for old `media:123` entity_browser format so existing blocks continue to render the background image after upgrade
- Replaces `getEntityBrowserValue()` in `blockSubmit()` with plain `$form_state->getValue()`

## Test plan

- [ ] `ddev drush cr` — no fatal errors (entity_browser import removed)
- [ ] Edit AF block config — media_library widget shows instead of entity browser
- [ ] Select a background image, save — config stores integer media ID
- [ ] Existing blocks with old `media:123` format still render background image correctly
- [ ] Re-save existing block — format auto-migrates to integer ID