### PR TITLE
fix: fix location filter when Limit by Locations is configured

### DIFF
--- a/src/OpenyActivityFinderSolrBackend.php
+++ b/src/OpenyActivityFinderSolrBackend.php
@@ -314,19 +314,30 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
     // Select locations based on filters.
     $locations = null;
     $locations_info = $this->getLocationsInfo();
-    $locations_nids = [];
 
-    // Get locations selected in parameters, if specified.
-    if (!empty($parameters['locations'])) {
-      $locations_nids = explode(',', rawurldecode($parameters['locations']));
-    }
+    // Collect the allowed set: limitloc param + config limitloc.
+    $limit_nids = [];
     if (!empty($parameters['limitloc'])) {
-      $locations_nids = array_merge($locations_nids, explode(',', $parameters['limitloc']));
+      $limit_nids = array_merge($limit_nids, explode(',', $parameters['limitloc']));
+    }
+    $locations_nids_config = array_filter(explode(',', $this->config->get('limitloc') ?? ''));
+    $limit_nids = array_unique(array_merge($limit_nids, $locations_nids_config));
+
+    // User-selected locations.
+    $selected_nids = [];
+    if (!empty($parameters['locations'])) {
+      $selected_nids = explode(',', rawurldecode($parameters['locations']));
     }
 
-    // Get configured location limits and merge with parameters.
-    $locations_nids_config = array_filter(explode(',', $this->config->get('limitloc') ?? ""));
-    $locations_nids = array_merge($locations_nids, $locations_nids_config);
+    // User selection intersected with allowed set; no selection = use allowed set.
+    if ($selected_nids) {
+      $locations_nids = $limit_nids
+        ? array_values(array_intersect($selected_nids, $limit_nids))
+        : $selected_nids;
+    }
+    else {
+      $locations_nids = $limit_nids;
+    }
 
     // Limit locations to parameters + limit.
     if ($locations_nids) {


### PR DESCRIPTION
## Bug

When **Limit by Locations** is configured on the Activity Finder block, selecting a specific location from the dropdown does not filter results — all configured locations remain visible.

## Root cause

`limitloc` (the allowed location set) was merged with user-selected `locations` via `array_merge` in `OpenyActivityFinderSolrBackend::runProgramSearch()`.

Example: block configured with JOHNSTOWN (NID 420) + LAFAYETTE (NID 431). User selects JOHNSTOWN.
- `locations=420` (user pick)
- `limitloc=420,431` (allowed set, always sent by Vue)
- `array_merge` → `[420, 431, 420]` → Solr gets both locations → no filtering effect

## Fix

Treat `limitloc` as an **intersection constraint**, not an additive list:

- User selected locations → intersect with `limitloc`
- No user selection → use `limitloc` as the full filter
- No `limitloc` configured → show all locations (existing behavior preserved)

## Testing

1. Configure Activity Finder block with 2 locations in "Limit by Locations"
2. Open Activity Finder results page — both locations appear in dropdown ✓
3. Select one location — results show only that location's sessions ✓
4. Deselect all — results show sessions from both configured locations ✓
5. Remove "Limit by Locations" config — all locations shown, filtering still works ✓